### PR TITLE
convert: add StringToByteSliceUnsafe and ByteSliceToStringUnsafe

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"strconv"
 	"time"
+	"unsafe"
 )
 
 // ToInt converts from to an int64.
@@ -49,4 +50,22 @@ func ToInt64(from any) int64 {
 	default:
 		return 0
 	}
+}
+
+// StringToByteSliceUnsafe converts a string to a byte slice
+// without copying, making this substantially faster
+// and less expensive than doing a direct convertion.
+//
+// StringToByteSliceUnsafe uses the unsafe package.
+func StringToByteSliceUnsafe(str string) []byte {
+	return *(*[]byte)(unsafe.Pointer(&str))
+}
+
+// ByteSliceToStringUnsafe converts a byte slice to a string
+// without copying, making this substantially faster
+// and less expensive than doing a direct convertion.
+//
+// ByteSliceToStringUnsaf uses the unsafe package.
+func ByteSliceToStringUnsafe(bs []byte) string {
+	return *(*string)(unsafe.Pointer(&bs))
 }

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func TestToInt64(t *testing.T) {
-	assert := assert.New(t)
-
 	for _, tc := range []struct {
 		name  string
 		input any
@@ -37,7 +35,17 @@ func TestToInt64(t *testing.T) {
 		{"empty-[]byte", []byte{}, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(tc.want, ToInt64(tc.input))
+			assert.Equal(t, tc.want, ToInt64(tc.input))
 		})
 	}
+}
+
+func TestStringToByteSliceUnsafe(t *testing.T) {
+	str := "foo, bar, baz, qux, quux"
+	assert.Equal(t, []byte(str), StringToByteSliceUnsafe(str))
+}
+
+func TestByteSliceToStringUnsafe(t *testing.T) {
+	bs := []byte("foo, bar, baz, qux, quux")
+	assert.Equal(t, "foo, bar, baz, qux, quux", ByteSliceToStringUnsafe(bs))
 }


### PR DESCRIPTION
This PR adds two more funcs to the convert package:
`StringToByteSliceUnsafe` and `ByteSliceToStringUnsafe`

While they do use the unsafe package, we can see this exact code being used in the std lib, for example [here](https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/strings/builder.go;l=47).

This makes converting these two types substantially faster because there is no copying. 