### PR TITLE
convert: refactor the convert package

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -6,47 +6,271 @@ import (
 	"time"
 )
 
+// ToInt converts from to an int.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
+func ToInt(from any) (int, error) {
+	return toInteger[int](from, false)
+}
+
+// ToInt8 converts from to an int8.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
+func ToInt8(from any) (int8, error) {
+	return toInteger[int8](from, false)
+}
+
+// ToInt16 converts from to an int16.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
+func ToInt16(from any) (int16, error) {
+	return toInteger[int16](from, false)
+}
+
+// ToInt32 converts from to an int32.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
+func ToInt32(from any) (int32, error) {
+	return toInteger[int32](from, false)
+}
+
 // ToInt64 converts from to an int64.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
 func ToInt64(from any) (int64, error) {
+	return toInteger[int64](from, false)
+}
+
+// ToUint converts from to an uint.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
+func ToUint(from any) (uint, error) {
+	return toInteger[uint](from, true)
+}
+
+// ToUint8 converts from to an uint8.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
+func ToUint8(from any) (uint8, error) {
+	return toInteger[uint8](from, true)
+}
+
+// ToUint16 converts from to an uint16.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
+func ToUint16(from any) (uint16, error) {
+	return toInteger[uint16](from, true)
+}
+
+// ToUint32 converts from to an uint32.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
+func ToUint32(from any) (uint32, error) {
+	return toInteger[uint32](from, true)
+}
+
+// ToUint64 converts from to an uint64.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
+func ToUint64(from any) (uint64, error) {
+	return toInteger[uint64](from, true)
+}
+
+// ToUintptr converts from to an uintptr.
+//
+// If from is an integer or a float, a time.Duration,
+// a time.Month or a time.Weekday a direct
+// type convertion will be made.
+//
+// If from is a bool, it will return 1 for
+// true and 0 for false.
+//
+// If from is time.Time, it will return
+// the Unix time.
+//
+// If it is a string, strconv will be used.
+//
+// No other types are allowed.
+func ToUintptr(from any) (uintptr, error) {
+	return toInteger[uintptr](from, true)
+}
+
+func toInteger[To strictInteger](from any, unsigned bool) (To, error) {
 	switch t := from.(type) {
 	case int:
-		return int64(t), nil
+		return To(t), nil
 	case int8:
-		return int64(t), nil
+		return To(t), nil
 	case int16:
-		return int64(t), nil
+		return To(t), nil
 	case int32:
-		return int64(t), nil
+		return To(t), nil
 	case int64:
-		return t, nil
+		return To(t), nil
 	case float32:
-		return int64(t), nil
+		return To(t), nil
 	case float64:
-		return int64(t), nil
+		return To(t), nil
 	case uint:
-		return int64(t), nil
+		return To(t), nil
 	case uint8:
-		return int64(t), nil
+		return To(t), nil
 	case uint16:
-		return int64(t), nil
+		return To(t), nil
 	case uint32:
-		return int64(t), nil
+		return To(t), nil
 	case uint64:
-		return int64(t), nil
-	case string:
-		return strconv.ParseInt(t, 10, 64)
+		return To(t), nil
+	case uintptr:
+		return To(t), nil
 	case time.Duration:
-		return int64(t), nil
+		return To(t), nil
 	case time.Month:
-		return int64(t), nil
+		return To(t), nil
 	case time.Weekday:
-		return int64(t), nil
+		return To(t), nil
+	case time.Time:
+		return To(t.Unix()), nil
 	case bool:
 		if t {
 			return 1, nil
 		}
 		return 0, nil
+	case string:
+		if unsigned {
+			x, err := strconv.ParseUint(t, 10, 64)
+			return To(x), err
+
+		}
+		x, err := strconv.ParseInt(t, 10, 64)
+		return To(x), err
 	default:
-		return 0, fmt.Errorf("convert: can not convert type %T to int64", t)
+		var zero To
+		return 0, fmt.Errorf("can not convert type '%T' to '%T'", t, zero)
 	}
+}
+
+type strictInteger interface {
+	int | int8 | int16 | int32 | int64 |
+		uint | uint8 | uint16 | uint32 | uint64 | uintptr
 }

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -18,9 +18,10 @@ import (
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToInt(from any) (int, error) {
 	return toInteger[int](from, false)
 }
@@ -37,9 +38,10 @@ func ToInt(from any) (int, error) {
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToInt8(from any) (int8, error) {
 	return toInteger[int8](from, false)
 }
@@ -56,9 +58,10 @@ func ToInt8(from any) (int8, error) {
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToInt16(from any) (int16, error) {
 	return toInteger[int16](from, false)
 }
@@ -75,9 +78,10 @@ func ToInt16(from any) (int16, error) {
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToInt32(from any) (int32, error) {
 	return toInteger[int32](from, false)
 }
@@ -94,9 +98,10 @@ func ToInt32(from any) (int32, error) {
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToInt64(from any) (int64, error) {
 	return toInteger[int64](from, false)
 }
@@ -113,9 +118,10 @@ func ToInt64(from any) (int64, error) {
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToUint(from any) (uint, error) {
 	return toInteger[uint](from, true)
 }
@@ -132,9 +138,10 @@ func ToUint(from any) (uint, error) {
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToUint8(from any) (uint8, error) {
 	return toInteger[uint8](from, true)
 }
@@ -151,9 +158,10 @@ func ToUint8(from any) (uint8, error) {
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToUint16(from any) (uint16, error) {
 	return toInteger[uint16](from, true)
 }
@@ -170,9 +178,10 @@ func ToUint16(from any) (uint16, error) {
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToUint32(from any) (uint32, error) {
 	return toInteger[uint32](from, true)
 }
@@ -189,9 +198,10 @@ func ToUint32(from any) (uint32, error) {
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToUint64(from any) (uint64, error) {
 	return toInteger[uint64](from, true)
 }
@@ -208,9 +218,10 @@ func ToUint64(from any) (uint64, error) {
 // If from is time.Time, it will return
 // the Unix time.
 //
-// If it is a string, strconv will be used.
+// If from is a string, strconv will be used.
 //
-// No other types are allowed.
+// No other types are allowed and will result
+// in an error.
 func ToUintptr(from any) (uintptr, error) {
 	return toInteger[uintptr](from, true)
 }
@@ -260,7 +271,6 @@ func toInteger[To strictInteger](from any, unsigned bool) (To, error) {
 		if unsigned {
 			x, err := strconv.ParseUint(t, 10, 64)
 			return To(x), err
-
 		}
 		x, err := strconv.ParseInt(t, 10, 64)
 		return To(x), err

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestToInt64(t *testing.T) {
+func TestToSignedInteger(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		input   any
@@ -24,19 +24,130 @@ func TestToInt64(t *testing.T) {
 		{"uint16", uint16(10), 10, false},
 		{"uint32", uint32(10), 10, false},
 		{"uint64", uint64(10), 10, false},
+		{"uintptr", uintptr(10), 10, false},
 		{"string-10", "10", 10, false},
 		{"string-a", "a", 0, true},
 		{"time-nanosecond", time.Nanosecond, 1, false},
 		{"time-month-5", time.Month(5), 5, false},
 		{"time-weekday-5", time.Weekday(5), 5, false},
+		{"time", time.Date(2022, 11, 30, 18, 41, 15, 10, time.UTC), 1669833675, false},
 		{"true", true, 1, false},
 		{"false", false, 0, false},
 		{"empty-[]byte", []byte{}, 0, true},
+		{"negative", -1, -1, false},
+		{"negative str", "-1", -1, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := ToInt64(tc.input)
+			got, err := toInteger[int64](tc.input, false)
 			if ((err != nil) != tc.wantErr) || tc.want != got {
-				t.Errorf("\ntest '%s' failed to convert\nwant: %v\ngot: %v\nwantErr: %v\nerr: %v", tc.name, tc.want, got, tc.wantErr, err)
+				t.Errorf("\ntest '%s' failed to convert\nwant: %v\ngot: %v\nwantErr: %v\nerr: %v",
+					tc.name, tc.want, got, tc.wantErr, err,
+				)
+			}
+		})
+	}
+}
+
+func TestToUnsignedInteger(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		input   any
+		want    uint64
+		wantErr bool
+	}{
+		{"int", int(10), 10, false},
+		{"int8", int8(10), 10, false},
+		{"int16", int16(10), 10, false},
+		{"int32", int32(10), 10, false},
+		{"int64", int64(10), 10, false},
+		{"float32", float32(10), 10, false},
+		{"float64", float64(10), 10, false},
+		{"uint", uint(10), 10, false},
+		{"uint8", uint8(10), 10, false},
+		{"uint16", uint16(10), 10, false},
+		{"uint32", uint32(10), 10, false},
+		{"uint64", uint64(10), 10, false},
+		{"uintptr", uintptr(10), 10, false},
+		{"string-10", "10", 10, false},
+		{"string-a", "a", 0, true},
+		{"time-nanosecond", time.Nanosecond, 1, false},
+		{"time-month-5", time.Month(5), 5, false},
+		{"time-weekday-5", time.Weekday(5), 5, false},
+		{"time", time.Date(2022, 11, 30, 18, 41, 15, 10, time.UTC), 1669833675, false},
+		{"true", true, 1, false},
+		{"false", false, 0, false},
+		{"empty-[]byte", []byte{}, 0, true},
+		{"negative", -1, 1<<64 - 1, false},
+		{"negative str", "-1", 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := toInteger[uint64](tc.input, true)
+			if ((err != nil) != tc.wantErr) || tc.want != got {
+				t.Errorf("\ntest '%s' failed to convert\nwant: %v\ngot: %v\nwantErr: %v\nerr: %v",
+					tc.name, tc.want, got, tc.wantErr, err,
+				)
+			}
+		})
+	}
+}
+
+func TestToIntegerFuncs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		f    func() error
+	}{
+		{
+			"ToInt",
+			func() error { _, err := ToInt(10); return err },
+		},
+		{
+			"ToInt8",
+			func() error { _, err := ToInt8(10); return err },
+		},
+		{
+			"ToInt16",
+			func() error { _, err := ToInt16(10); return err },
+		},
+		{
+			"ToInt32",
+			func() error { _, err := ToInt32(10); return err },
+		},
+		{
+			"ToInt64",
+			func() error { _, err := ToInt64(10); return err },
+		},
+		{
+			"ToUint",
+			func() error { _, err := ToUint(10); return err },
+		},
+		{
+			"ToUint",
+			func() error { _, err := ToUint(10); return err },
+		},
+		{
+			"ToUint8",
+			func() error { _, err := ToUint8(10); return err },
+		},
+		{
+			"ToUint16",
+			func() error { _, err := ToUint16(10); return err },
+		},
+		{
+			"ToUint32",
+			func() error { _, err := ToUint32(10); return err },
+		},
+		{
+			"ToUint64",
+			func() error { _, err := ToUint64(10); return err },
+		},
+		{
+			"ToUintptr",
+			func() error { _, err := ToUintptr(10); return err },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.f(); err != nil {
+				t.Errorf("\ntest '%s' failed\nerr: %v", tc.name, err)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds a bunch of new functions: `ToInt`, `ToInt8`, `ToInt16`, `ToInt32`, `ToUint`, `ToUint8`, `ToUint16`, `ToUint32`, `ToUint64`, `ToUintptr`.

`uintptr`s are now handled, and so is `time.Time`. In case of `time.Time` the result will be `time.Time.Unix()`.