### PR TITLE
cache: reduce memory used and gc cycles

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -142,7 +142,7 @@ func TestCache(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			c := NewCache[string, any](tc.cacheFor)
+			c := New[string, any](tc.cacheFor)
 			if err := tc.f(c); err != nil {
 				t.Errorf("\ntest '%s' failed\nerr: %v", tc.name, err)
 			}


### PR DESCRIPTION
Instead of using `time.Time` in the items, we are now storing the unix timestamp. Reason being that `time.Time` stores are pointer to `time.Location` and this increases memory usage and gc cycles. We don't need the location data for this package, so it is ok to remove it.